### PR TITLE
fix: increase express.json body limit to 50mb for media uploads

### DIFF
--- a/server/json-server.js
+++ b/server/json-server.js
@@ -11,7 +11,7 @@ const UPLOAD_DIR = path.join(__dirname, 'uploads');
 
 // Middleware
 app.use(cors());
-app.use(express.json());
+app.use(express.json({ limit: '50mb' }));
 app.use('/uploads', express.static(UPLOAD_DIR));
 
 // Путь к файлу с данными (users, thoughts, старый формат эмоций)


### PR DESCRIPTION
Image and audio files encoded as base64 easily exceed the default 100kb limit, causing 413 Payload Too Large errors on /api/upload.

https://claude.ai/code/session_016n8mAXnnNjM5tdrvXc8arY